### PR TITLE
fixed authorization error because of db_name

### DIFF
--- a/app/db/db.py
+++ b/app/db/db.py
@@ -2,13 +2,13 @@ import os
 import pymongo as pm
 
 client = "unset"
-db_name = os.environ.get("DB_NAME")
+db_name = "default"
 db = None
 users_collection = None
 
 
 def connect_db(testing=False):
-    global client, db, users_collection
+    global client, db, users_collection, db_name
     if client == "unset":
         if os.environ.get("testing") == "false":
             password = os.environ.get("M_PASS")
@@ -20,6 +20,7 @@ def connect_db(testing=False):
             url = url + "/?retryWrites=true&w=majority"
             client = pm.MongoClient(url.format(password, username))
             db = client[db_name]
+
             users_collection = db.users
             try:
                 print(users_collection)
@@ -30,6 +31,6 @@ def connect_db(testing=False):
             password = "example"
             username = "root"
             client = pm.MongoClient()
-            if not testing:
-                db = client[db_name]
-                users_collection = db.users
+            # if not testing:
+            db = client[db_name]
+            users_collection = db.users


### PR DESCRIPTION
Worked out a bug that was occuring with the environment running in production code where the database name was not being passed in as a string, even though the database didn't have a name and didn't need to be passed in, yet was still causing the error.